### PR TITLE
fixed Poco include to work with OF0.8.0

### DIFF
--- a/src/ofxTween.h
+++ b/src/ofxTween.h
@@ -1,7 +1,7 @@
 #ifndef TWEEN_INCLUDED
 #define TWEEN_INCLUDED
 
-#include "Poco/Timestamp.h"
+#include <Poco/Delegate.h>
 #include "ofxEasing.h"
 #include "ofMain.h"
 


### PR DESCRIPTION
Hi,

I had to change the Poco include to use ofxTween with OF0.8.0

Best,

Hugues.
